### PR TITLE
feat(localcollection): allow supressing removal warnings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,12 +145,17 @@ class PublicationClient extends EventEmitter {
    * one is created and then returned.
    *
    * @param {String} name The name of the collection to return.
+   * @param      {Object} [opts] Options to set on the collection if it's created.
+   * @param      {bool}   [opts.supressRemovalWarnings]  If true, do not throw when we receive a
+   *   removed event and there is no corresponding document. This is useful for situations where
+   *   collections state is managed optimistically on the client rather than waiting for a server
+   *   response (e.g. calling model.destroy() from a backbone model).
    * @returns {LocalCollection} The collection to return.
    */
-  getCollection(name) {
+  getCollection(name, options = {}) {
     var collection = this._collections[name];
     if (!collection) {
-      collection = this._collections[name] = new LocalCollection(name, this);
+      collection = this._collections[name] = new LocalCollection(options);
     }
     return collection;
   }

--- a/src/localCollection.js
+++ b/src/localCollection.js
@@ -15,10 +15,17 @@ import { expandKeys, deepExtend } from './utils';
 class LocalCollection extends EventEmitter {
   /**
    * Constructs a new LocalCollection.
+   *
+   * @param      {Object} [opts]
+   * @param      {bool}   [opts.supressRemovalWarnings]  If true, do not throw when we receive a
+   *   removed event and there is no corresponding document. This is useful for situations where
+   *   collections state is managed optimistically on the client rather than waiting for a server
+   *   response (e.g. calling model.destroy() from a backbone model).
    */
-  constructor() {
+  constructor({ supressRemovalWarnings } = {}) {
     super();
     this._docs = {};
+    this._supressRemovalWarnings = !!supressRemovalWarnings;
   }
 
   /**
@@ -85,6 +92,7 @@ class LocalCollection extends EventEmitter {
   _onRemoved(id) {
     var doc = this._docs[id];
     if (!doc) {
+      if (this._supressRemovalWarnings) return;
       throw new Error('Document has been removed without having been added!');
     }
     delete this._docs[id];


### PR DESCRIPTION
For a long time we've dealt with unactionable errors when the
`_onRemoved` function is triggered for `LocalCollection`s in cases where
we intentionally, optimistically removed a document from the collection.

This allows consumers of `publication-client` the ability to opt-in to
warning supression. This achieves the goal of warning about potential
issues with document removal, but allows one to investigate, determine
if there's an issue, and opt-out of noisy warnings.