### PR TITLE
feat: enable reconnecting when paranoid mode is requested

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -153,10 +153,9 @@ class PublicationClient extends EventEmitter {
     // If we haven't received any data since the last time we checked,
     // force a reconnect.
     if (Date.now() - this._lastDataTimestamp > this._lastDataTimeout) {
-      // TODO(ryanf): Temporarily disabled while we collect stats.
-      /*this._client.end();
+      this._client.end();
       this._client = this._initializeClient(this._url, this._options);
-      this._resetCollectionsAndConnect();*/
+      this._resetCollectionsAndConnect();
       this.emit('proactivelyReconnected', reason);
     }
 


### PR DESCRIPTION
This enables the logic to actually reconnect primus when the paranoid mode reconnect is triggered.