### PR TITLE
fix: make reconnection less aggressive

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,6 +83,12 @@ class PublicationClient extends EventEmitter {
       url,
       _.defaults(options, {
         strategy: ['online', 'disconnect'],
+        reconnect: {
+          min: 1000,
+          max: Infinity,
+          retries: 10,
+          factor: 2,
+        },
       })
     );
 


### PR DESCRIPTION
#### Changes Made
This PR makes reconnection via the Primus client less aggressive, as per [these options](https://github.com/primus/primus#reconnect). At our scale, this is important; we do not want to have a ton of preprovisioned capacity to handle swapping out servers gracefully (ie, restarting during a deploy or similar.) 

The only value we're changing from the defaults is the starting backoff, from 500ms to 1s. With 10 max attempts at an exponential factor of 2 and a starting value of 1 second, our maximum wait between reconnection attempts will be 1s * 2^10 = 1024s, or 17 minutes, relieving the pressure on the service by about half (in other words, doubling the reconnection time.)

#### Potential Risks
There's the potential that this timeout value is too long, but that window is unlikely given that this is simply doubling.

#### Test Plan
I will stamp a release and test this in our staging environment by force-ably terminating my connections on client side and watching browser retry times.

#### Checklist
- [ ] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
