### PR TITLE
feat: add req on publication-server version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ci:commitlint": "commitlint-jenkins --pr-only",
     "prebuild": "rm -rf dist",
     "prepublishOnly": "npm run build && if [ \"$CI\" = '' ]; then node -p 'JSON.parse(process.env.npm_package_config_manualPublishMessage)'; exit 1; fi",
-    "semantic-release": "semantic-release",
+    "semantic-release": "SEMANTIC_COMMITLINT_SKIP=987b5c1 semantic-release",
     "lint": "eslint .",
     "test": "jest",
     "ci": "npm run lint && npm run test",


### PR DESCRIPTION
BREAKING CHANGE: we now require a publication-server version
of version 2 or higher.

#### Changes Made
 - See above

#### Potential Risks
 - Break the build

#### Test Plan
 - Try releasing

#### Checklist
- [ ] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
