### PR TITLE
feat: adding support for publications options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
 node_modules/
+.idea/

--- a/src/index.js
+++ b/src/index.js
@@ -262,12 +262,40 @@ class PublicationClient extends EventEmitter {
 
     // Hash the name and params to cache the subscription.
     const subscriptionKey = JSON.stringify(_.toArray(arguments));
-    var subscription = this._subscriptions[subscriptionKey];
+    let subscription = this._subscriptions[subscriptionKey];
     if (!subscription) {
       subscription = this._subscriptions[subscriptionKey] = new Subscription(
         String(id),
         name,
         params,
+        this
+      );
+    }
+    return subscription;
+  }
+
+  /**
+   * Subscribe to the publication with the given name. Any other parameters
+   * are passed as arguments to the publication.
+   *
+   * @param {String} name The publication to subscribe to.
+   * @param {Object} options containing optional parameters such as bootstrap and/or
+   * bootstrapAsync.
+   * @param {*[]} params (optional) Params to pass to the publication.
+   * @returns {Subscription} The subscription to the desired publication.
+   */
+  subscribeWithOptions(name, options, ...params) {
+    const id = this._nextSubscriptionId++;
+    const payload = [...params, options];
+
+    // Hash the name and params to cache the subscription including payload extended with options.
+    const subscriptionKey = JSON.stringify([name].concat(payload));
+    let subscription = this._subscriptions[subscriptionKey];
+    if (!subscription) {
+      subscription = this._subscriptions[subscriptionKey] = new Subscription(
+        String(id),
+        name,
+        payload,
         this
       );
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -37,5 +37,25 @@ describe('PublicationClient', () => {
       expect(pub.emit).toHaveBeenCalledWith('proactivelyReconnected', 'test');
       jest.clearAllTimers();
     });
+
+    it('calls new method with correct parameters', () => {
+      const pub = new PublicationClient('https://127.0.0.1', {
+        lastDataTimeout: 1,
+        paranoid: true,
+      });
+      pub._lastDataTimestamp = 0;
+      pub.reconnectIfIdle('test');
+      const subscription = pub.subscribeWithOptions(
+        'test',
+        { bootstrap: false },
+        { key: 1 },
+        { key: 2 }
+      );
+      expect(pub._subscriptions).not.toBe({});
+      expect(subscription._params).toStrictEqual([{ key: 1 }, { key: 2 }, { bootstrap: false }]);
+      subscription.stop();
+      expect(pub._subscriptions).toStrictEqual({});
+      jest.clearAllTimers();
+    });
   });
 });


### PR DESCRIPTION
#### Changes Made
Support for extending publications subscribe with options.

Cherry-picking the initial PR from https://github.com/mixmaxhq/publication-client/pull/22 to the 2.x

#### Potential Risks
<!--- What can go wrong with this change? How will these changes affect adjacent code/features? How will we handle any adverse issues? --->
low

#### Test Plan
<!--- How do we know this PR does what it's supposed to do? How do we ensure that adjacent code/features are still working? How do we evaluate the performance implications of this PR?--->
unit tests

#### Checklist
- [ ] I've increased test coverage
- [ ] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
