### PR TITLE
fix: emit event on removal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "publication-client",
-  "version": "2.4.3",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/localCollection.js
+++ b/src/localCollection.js
@@ -80,9 +80,7 @@ class LocalCollection extends EventEmitter {
    * @param {String} id The ID of the document to remove.
    */
   _onRemoved(id) {
-    var doc = this._docs[id];
-    if (!doc) return;
-
+    var doc = this._docs[id] || { _id: id };
     delete this._docs[id];
 
     this.emit('removed', doc);


### PR DESCRIPTION
#### Changes Made
After we avoided supressing removal warnings, we should actually pass the remove event to the publication collection rather than swallowing it. This ensures we can remove models from the backbone collection even if they don't have a corresponding added event from the publication collection.

Found while testing removing bootstrapped publications, it looks like we don't currently handle `remove` publications for non-bootstrapped collections. This should fix that.

#### Potential Risks
small. it's possible we relied on this event elsewhere and will cause some errors. However, the backbone publication collection has a check to be sure the model exists by id prior to removing it so we should be safe.

#### Test Plan
- [x] remove a feature in app and be sure the ui updates.
- [x] remove a group in app and be sure the ui updates.
