### PR TITLE
fix: emit event on removal regardless

### DIFF
--- a/src/localCollection.js
+++ b/src/localCollection.js
@@ -90,11 +90,7 @@ class LocalCollection extends EventEmitter {
    * @param {String} id The ID of the document to remove.
    */
   _onRemoved(id) {
-    var doc = this._docs[id];
-    if (!doc) {
-      if (this._supressRemovalWarnings) return;
-      throw new Error('Document has been removed without having been added!');
-    }
+    var doc = this._docs[id] || { _id: id };
     delete this._docs[id];
 
     this.emit('removed', doc);


### PR DESCRIPTION
#### Changes Made
Remove suppression of removal events when the document doesn't exist in the local collection. We should attempt removal regardless.

Cherry picked from: https://github.com/mixmaxhq/publication-client/pull/24

#### Potential Risks
small. this change helps resolve errors.

#### Test Plan
we've been running similar changes on production for quite some time.
