### PR TITLE
feat: add option to subscribe to callbacks instead of collections

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -58,4 +58,126 @@ describe('PublicationClient', () => {
       jest.clearAllTimers();
     });
   });
+
+  describe('subscribe via callbacks', () => {
+    const onReconnectedEvent = jest.fn();
+    const onAddedEvent = jest.fn();
+    const onChangedEvent = jest.fn();
+    const onRemovedEvent = jest.fn();
+
+    const callbacks = {
+      added: onAddedEvent,
+      changed: onChangedEvent,
+      removed: onRemovedEvent,
+    };
+
+    const pub = new PublicationClient('https://127.0.0.1', {
+      lastDataTimeout: 1,
+      paranoid: true,
+    });
+    const defaultMessage = {
+      collection: 'sequence',
+      id: '62e76f79a1016bb8a303ef6b',
+    };
+    const defaultResponse = [defaultMessage.collection, defaultMessage.id];
+    const callbacksResponse = {
+      added: [...defaultResponse, undefined],
+      changed: [...defaultResponse, undefined, undefined],
+      removed: [...defaultResponse],
+    };
+
+    beforeEach(() => {
+      pub._collections = [];
+      pub._subscriptions = [];
+      pub.unsubscribeEventFromCallbacks([]);
+      pub.subscribeEventsToCallbacks(
+        onReconnectedEvent,
+        onAddedEvent,
+        onChangedEvent,
+        onRemovedEvent
+      );
+    });
+
+    test.each(['added', 'changed', 'removed'])(
+      'calls the event callback and updates the collection if collection subscribed via callbacks and it was created by backbone pubilcations on receiving %s event',
+      (event) => {
+        const message = {
+          msg: event,
+          collection: 'sequence',
+          id: '62e76f79a1016bb8a303ef6b',
+        };
+        pub.subscribeViaCallbacks(message.collection);
+        pub._collections[message.collection] = {};
+
+        const getCollectionsMock = jest.spyOn(pub, 'getCollection');
+        getCollectionsMock.mockReturnValue({
+          _onRemoved: jest.fn(),
+          _onChanged: jest.fn(),
+          _onAdded: jest.fn(),
+        });
+        pub._handleMessage(message);
+        expect(callbacks[event]).toHaveBeenCalled();
+        expect(pub.getCollection).toHaveBeenCalled();
+      }
+    );
+    test.each(['added', 'changed', 'removed'])(
+      'does not call callback, but updates collection if collection not subscribed via callbacks but was created by backbone pubilcations on receiving an %s event',
+      (event) => {
+        const message = {
+          msg: event,
+          collection: 'sequence',
+          id: '62e76f79a1016bb8a303ef6b',
+        };
+        pub._collections[message.collection] = {};
+        const getCollectionsMock = jest.spyOn(pub, 'getCollection');
+        getCollectionsMock.mockReturnValue({
+          _onRemoved: jest.fn(),
+          _onChanged: jest.fn(),
+          _onAdded: jest.fn(),
+        });
+        pub._handleMessage(message);
+        expect(callbacks[event]).not.toHaveBeenCalled();
+        expect(pub.getCollection).toHaveBeenCalled();
+      }
+    );
+    test.each(['added', 'changed', 'removed'])(
+      'calls the event callback and not updates the collection if collection subscribed via callbacks and it was not created by backbone pubilcations on receiving %s event',
+      (event) => {
+        const message = {
+          msg: event,
+          ...defaultMessage,
+        };
+        pub.subscribeViaCallbacks(message.collection);
+        jest.spyOn(pub, 'getCollection');
+        pub._handleMessage(message);
+        expect(callbacks[event]).toHaveBeenCalledWith(...callbacksResponse[event]);
+        expect(pub.getCollection).not.toHaveBeenCalled();
+      }
+    );
+
+    it('remove on unsubscribe subscription created', () => {
+      const event = {
+        name: 'sequence',
+        options: {
+          sequenceIds: ['62e76f79a1016bb8a303ef6b'],
+          ids: ['62e76f79a1016bb8a303ef6b'],
+          onlyNew: true,
+        },
+      };
+      pub._subscriptions = [];
+      pub.subscribeViaCallbacks(event.name, event.options);
+      pub.unsubscribeEventFromCallbacks([event]);
+      expect(pub._subscriptions).toEqual([]);
+    });
+
+    it('remove on unsubscribe subscription created without options', () => {
+      const event = {
+        name: 'orgs',
+      };
+      pub._subscriptions = [];
+      pub.subscribeViaCallbacks(event.name);
+      pub.unsubscribeEventFromCallbacks([event]);
+      expect(pub._subscriptions).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
Jira:
https://mixmaxhq.atlassian.net/browse/ATMT-268

Changes Made:
- add method to subscribe via callbacks
- add method to unsubscribe via callbacks
- if subscribed via callbacks the add, change, remove, reconnect events will call the callback instead of updating backbone collection

Potential Risks:
Low.

Test Plan:
Deploy