### PR TITLE
fix: fix regression for multiple `whenReady` calls

### DIFF
--- a/src/subscription.js
+++ b/src/subscription.js
@@ -159,9 +159,6 @@ class Subscription extends EventEmitter {
   _whenReadyResolver() {
     this.removeListener('nosub', this._boundWhenReadyRejecter);
     this._whenReadyResolveFn();
-    // Reset `whenReady` handlers
-    this._whenReadyResolveFn = null;
-    this._whenReadyRejectFn = null;
   }
 
   /**
@@ -170,9 +167,6 @@ class Subscription extends EventEmitter {
   _whenReadyRejecter(err) {
     this.removeListener('ready', this._boundWhenReadyResolver);
     this._whenReadyRejectFn(err);
-    // Reset `whenReady` handlers
-    this._whenReadyResolveFn = null;
-    this._whenReadyRejectFn = null;
   }
 
   /**

--- a/test/subscription.test.js
+++ b/test/subscription.test.js
@@ -60,4 +60,15 @@ describe('Subscription', () => {
       sub.emit('ready');
     }).not.toThrow(TypeError);
   });
+
+  it('should not trigger error if `whenReady` is called multiple times', () => {
+    const sub = new Subscription('foo', 'fooSub', {}, conn);
+    // Calling more than once to subscribe multiple times to the `ready` event
+    sub.whenReady();
+    sub.whenReady();
+    // Triggering `ready` shouldn't cause errors
+    expect(() => {
+      sub.emit('ready');
+    }).not.toThrow(TypeError);
+  });
 });


### PR DESCRIPTION
#### Changes Made

Regression was introduced in [this PR](https://github.com/mixmaxhq/publication-client/pull/37).
[These lines](https://github.com/mixmaxhq/publication-client/blob/4545d891056514b0e9d059c0acc8dfeb59b74585/src/subscription.js#L162-L164) set resolve/reject handlers to `null` after  `ready` or `nosub` events are triggered. This might lead to error when we have multiple subscriptions to `whenReady`. Check out new test for a simple repro.

#### Potential Risks

New issue was discovered — we never truly supported subscribing multiple times to `whenReady`. Each time we create a new `Promise`, but we keep only the last resolve/reject handlers. On [this line](https://github.com/mixmaxhq/publication-client/blob/4545d891056514b0e9d059c0acc8dfeb59b74585/src/subscription.js#L148) we redefine previous value. But at the same time we do subscribe to `ready` event again.

This means that if we call `whenReady()` `N` times, we also `N` times subscribe to `ready` event. But we always redefine `resolve` value to the last created promise. It means that last resolve handler will be called `N` times, so only latest `whenReady` will be called. Though It will be called only once, because `resolve` will immediately trigger `then` and next `resolve()` calls won't have any effect.

Example:

```js
const sub = new Subscription(...);
sub.whenReady().then(() => console.log(1));
sub.whenReady().then(() => console.log(2));
sub.whenReady().then(() => console.log(3));
sub.emit('ready');
```

We will see only one log which contains `3` in the console.

#### Test Plan

Publications should work normally:
- Link package to a service;
- Open multiple pages that use publications (e.g. General settings in Mixmax dashboard);
- Verify that publications work — update a field in one tab and check that it's updated in the other one too (e.g. update theme).

#### Checklist
- [x] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
